### PR TITLE
add batch modification form

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -19,6 +19,7 @@
                             <b-dropdown-item to="/startdefinition">Start processes</b-dropdown-item>
                             <b-dropdown-item to="/complexmigration">Migration</b-dropdown-item>
                             <b-dropdown-item to="/variablebatch">Variables edit</b-dropdown-item>
+                            <b-dropdown-item to="/modificationbatch">Modification</b-dropdown-item>
                         </b-nav-item-dropdown>
                         <b-nav-item-dropdown text="Decisions">
                             <b-dropdown-item to="/decisiondefinitions">Stats and definitions</b-dropdown-item>

--- a/src/components/modification/BatchModification.vue
+++ b/src/components/modification/BatchModification.vue
@@ -1,0 +1,292 @@
+<template>
+  <div id="batch-modification">
+    <h2>Batch modification</h2>
+    <b-card title="1. Select process and activities">
+      <div class="form-group">
+        <label>Process Definition Key</label>
+        <vue-bootstrap-typeahead
+            style="width:100%"
+            @hit="selectedDefinition =$event"
+            :serializer="serialazier"
+            v-model="selectedDefinition.id"
+            :data="processDefinitions"
+        />
+      </div>
+      <div class="form-group">
+        <label>Process Definition Version</label>
+        <b-form-select
+            v-on:change="refreshComponentKey"
+            id="select"
+            v-model="processDefinition.id"
+            :options="processDefinition.versions"
+        />
+      </div>
+      <definition-diagram
+          :hideSuspend="true"
+          :key="componentKey"
+          :definitionId="processDefinition.id"
+          v-on:DefinitionDiagramClick="handleClick"
+      ></definition-diagram>
+      <b-container fluid="false" v-if="processDefinition.id.length !== 0">
+        <b-row class="mt-3">
+          <b-col md="auto">
+            <b-btn variant="outline-primary" @click="assignFromActivity">From</b-btn>
+          </b-col>
+          <b-col md="auto" align-self="center">
+            <p v-if="activityFrom != null">{{ activityFrom }}</p>
+            <p v-if="activityFrom == null">Please, select activity and press <b>From</b> button</p>
+          </b-col>
+          <b-col md="auto">
+            <b-btn class="mb-2" variant="link" @click="activityFrom = null">x</b-btn>
+          </b-col>
+        </b-row>
+        <b-row class="mt-3">
+          <b-col md="auto">
+            <b-btn variant="outline-primary" @click="assignToActivity">To</b-btn>
+          </b-col>
+          <b-col md="auto" align-self="center">
+            <p v-if="activityTo != null">{{ activityTo }}</p>
+            <p v-if="activityTo == null">Please, select activity and press <b>To</b> button</p>
+          </b-col>
+          <b-col md="auto">
+            <b-btn class="mb-2" variant="link" @click="activityTo = null">x</b-btn>
+          </b-col>
+        </b-row>
+        <b-row class="mt-3">
+          <b-col md="auto">
+            <b-form-radio v-model="startActivityOption" value="before">Start <b>Before</b> activity
+            </b-form-radio>
+            <b-form-radio v-model="startActivityOption" value="after">Start <b>After</b> activity
+            </b-form-radio>
+          </b-col>
+        </b-row>
+      </b-container>
+    </b-card>
+    <b-card title="2. Filter processes">
+      <div class="form-group">
+        <b-form-checkbox
+            id="only-incidents-checkbox"
+            v-model="onlyIncidents"
+            value="true"
+            unchecked-value="false"
+        >
+          Only filedJob incidents
+        </b-form-checkbox>
+        <b-form-checkbox
+            id="by-business-key-checkbox"
+            v-model="byBusinessKey"
+            value="true"
+            unchecked-value="false"
+        >
+          By businessKey
+        </b-form-checkbox>
+        <b-container fluid="false" v-if="byBusinessKey === 'true'">
+          <b-row class="mt-3">
+            <b-col>
+              <b-form-textarea
+                  id="business-key-list"
+                  v-model="businessKeysText"
+                  placeholder="Enter list of businessKeys, one per row"
+                  rows="10"
+                  no-resize
+              ></b-form-textarea>
+            </b-col>
+          </b-row>
+        </b-container>
+      </div>
+    </b-card>
+    <b-card title="3. Generate request">
+      <div class="form-group">
+        <b-btn @click="generateRequest">Generate</b-btn>
+        <vue-json-editor v-if="request != null" v-model="request"
+                         :show-btns="true"></vue-json-editor>
+      </div>
+    </b-card>
+    <b-card title="4. Run modification">
+      <div class="form-group">
+        <b-btn @click="runModification">Run</b-btn>
+      </div>
+    </b-card>
+  </div>
+</template>
+
+<script>
+import VueBootstrapTypeahead from "vue-bootstrap-typeahead";
+import vueJsonEditor from 'vue-json-editor'
+
+const START_ACTIVITY_OPTION = {
+  BEFORE: 'startBeforeActivity',
+  AFTER: 'startAfterActivity',
+}
+
+export default {
+  name: "batch-modification",
+  components: {
+    VueBootstrapTypeahead, vueJsonEditor
+  },
+  data() {
+    return {
+      processKey: "",
+      selectedDefinition: "",
+      processDefinitions: [],
+      componentKey: 0,
+      processDefinition: {
+        id: "",
+        xml: "",
+        versions: [],
+        statistics: []
+      },
+      selectedActivity: null,
+      activityFrom: null,
+      activityTo: null,
+      startActivityOption: "before",
+      onlyIncidents: false,
+      byBusinessKey: false,
+      businessKeysText: "",
+      request: null
+    }
+  },
+  mounted() {
+    this.getDefinitions();
+  },
+  watch: {
+    selectedDefinition(newValue, oldValue) {
+      this.getVersions(newValue.key);
+      this.refreshComponentKey()
+      this.processDefinition.id = ""
+      this.processDefinition.xml = ""
+      this.processDefinition.statistics = []
+    }
+  },
+  methods: {
+    handleClick(payload) {
+      if (payload.$type !== "bpmn:Participant" && payload.$type !== "bpmn:SequenceFlow"
+          && payload.$type !== "bpmn:Collaboration") {
+        this.selectedActivity = payload.id;
+      }
+    },
+    assignFromActivity() {
+      this.activityFrom = this.selectedActivity
+    },
+    assignToActivity() {
+      this.activityTo = this.selectedActivity
+    },
+    generateRequest() {
+      this.$api()
+      .get(
+          `/process-instance?processDefinitionId=${this.processDefinition.id}&activityIdIn=${this.activityFrom}${this.onlyIncidents
+          === "true" ? '&incidentType=failedJob' : ''}`
+      )
+      .then(response => {
+        const processInstanceIds = this.applyFilters(response.data).map(process => process.id)
+        this.request = {
+          skipCustomListeners: true,
+          skipIoMappings: true,
+          processDefinitionId: this.processDefinition.id,
+          processInstanceIds: processInstanceIds,
+          instructions: this.createInstructions()
+        };
+      })
+      .catch(error => {
+        this.request = null
+        this.$notify({
+          group: "foo",
+          title: 'Cannot get process instance ids for selected filters',
+          text: error,
+          type: "error"
+        });
+      });
+    },
+    createInstructions() {
+      let instructions = []
+      if (this.activityFrom !== null) {
+        instructions.push({
+          type: "cancel",
+          activityId: this.activityFrom
+        })
+      }
+      if (this.activityTo !== null) {
+        instructions.push({
+          type: this.startActivityOption === "before" ? START_ACTIVITY_OPTION.BEFORE
+              : START_ACTIVITY_OPTION.AFTER,
+          activityId: this.activityTo
+        })
+      }
+      return instructions
+    },
+    applyFilters(processes) {
+      if (this.byBusinessKey !== "true") {
+        return processes
+      }
+      const businessKeys = new Set(this.businessKeysText.match(/[^\r\n]+/g))
+      return processes.filter(process => businessKeys.has(process.businessKey))
+    },
+    runModification() {
+      this.$api()
+      .post(
+          "/modification/executeAsync",
+          this.request
+      )
+      .then(() => {
+        this.$notify({
+          group: "foo",
+          title: "Batch created",
+          text: "Modification batch created",
+          type: "success"
+        });
+      })
+      .catch(error => {
+        this.$notify({
+          group: "foo",
+          title: "Not moved",
+          text: error,
+          type: "error"
+        });
+      });
+    },
+    refreshComponentKey() {
+      this.activityTo = null
+      this.activityFrom = null
+      this.componentKey = this.componentKey + 1;
+
+    },
+    getDefinitions() {
+      this.$api().get('/process-definition?latestVersion=true').then(response => {
+        this.processDefinitions = response.data;
+      })
+    },
+    getVersions(processKey) {
+      this.$api().get('/process-definition?key=' + processKey).then(response => {
+        this.processDefinition.versions = response.data.map(element => (
+            {
+              value: element.id,
+              text: `v${element.version} (${element.id})`
+            }
+        ))
+      })
+      .catch(error => {
+        this.processDefinition.versions = []
+        this.$notify({
+          group: "foo",
+          title: "Error during fetching process definition versions",
+          text: error,
+          type: "error"
+        });
+      });
+    },
+    serialazier(item) {
+      if (!item.name) {
+        return item.key
+      }
+      return `${item.key} (${item.name})`
+    }
+  }
+
+}
+</script>
+
+<style>
+.jsoneditor {
+  height: 600px;
+}
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -57,6 +57,9 @@ Vue.component('detail-jobs', DetailJobs);
 import ComplexMigration from '@/components/migration/ComplexMigration.vue';
 Vue.component('complex-migration', ComplexMigration);
 
+import BatchModification from '@/components/modification/BatchModification.vue';
+Vue.component('batch-modification', BatchModification);
+
 import VariableSingleEidt from '@/components/VariableSingleEdit.vue';
 Vue.component('variable-single-edit', VariableSingleEidt);
 

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -35,6 +35,7 @@ import UsersView from '@/views/UsersView.vue';
 import SystemsView from '@/views/SystemsView.vue';
 
 import VariableBatchModifyView from '@/views/VariableBatchModifyView.vue';
+import BatchModificationView from "@/views/BatchModificationView";
 
 Vue.use(Router);
 Vue.use(VueSmartRoute);
@@ -73,6 +74,11 @@ const router = new Router({
       path: '/variablebatch',
       name: 'variablebatch',
       component: VariableBatchModifyView
+    },
+    {
+      path: '/modificationbatch',
+      name: 'modificationbatch',
+      component: BatchModificationView
     },
     
     {

--- a/src/views/BatchModificationView.vue
+++ b/src/views/BatchModificationView.vue
@@ -1,0 +1,14 @@
+<template>
+  <div id="batchModificationView">
+    <batch-modification/>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "batchModificationView"
+};
+</script>
+
+<style>
+</style>


### PR DESCRIPTION
Added new **Modification** menu item in **Process** tab to execute batch process modifications with specified instructions (using [/modification/executeAsync](https://docs.camunda.org/manual/latest/reference/rest/modification/post-modification-async/)) 

- selecting FROM and TO activities to move (for most commonly use cases) and selecting startBeforeActivity or startAfterActivity options for this case
- filtering process instances by businessKeys or/and includes only failedJob incidents
- editing generated request to execute custom instructions