### PR TITLE
Process definition: get all businessKeys by activity

### DIFF
--- a/src/components/detail-process-definition/DefinitionRunTimeInstances.vue
+++ b/src/components/detail-process-definition/DefinitionRunTimeInstances.vue
@@ -18,6 +18,10 @@
         />
       </b-input-group>
       <b-button @click="initialGetProcessInstances" variant="success">Search</b-button>
+      <b-button class="ml-2" v-if="this.selected === 'activityId' && this.variable"
+                @click="downloadBusinessKeys"
+                variant="outline-primary">Get all businessKeys
+      </b-button>
       <b-button @click="clear" variant="link">Clear</b-button>
     </b-form>
     <small>Total: {{runtimeCount}}, Search result: {{searchCount}}</small>
@@ -221,6 +225,31 @@ export default {
     },
     calculateTotalPage() {
       this.totalPage = Math.round(this.runtimeCount / this.maxResult) + 1;
+    },
+    downloadBusinessKeys() {
+      this.$api()
+      .post("/process-instance", {
+        processDefinitionId: this.definitionId,
+        activityIdIn: [this.variable]
+      })
+      .then(response => {
+        const businessKeys = response.data.map(it => it.businessKey).join('\n')
+        const url = window.URL.createObjectURL(new Blob([businessKeys]))
+        const link = document.createElement('a')
+        link.href = url
+        link.setAttribute('download', `${this.variable}-businessKeys`)
+        document.body.appendChild(link)
+        link.click()
+        document.body.removeChild(link)
+      })
+      .catch(error => {
+        this.$notify({
+          group: "foo",
+          title: 'Cannot get process business keys for selected activity',
+          text: error,
+          type: "error"
+        });
+      })
     }
   }
 };

--- a/src/components/modification/BatchModification.vue
+++ b/src/components/modification/BatchModification.vue
@@ -104,7 +104,7 @@
     </b-card>
     <b-card title="4. Run modification">
       <div class="form-group">
-        <b-btn @click="runModification">Run</b-btn>
+        <b-btn v-bind:disabled="isRunDisabled" @click="runModification">Run</b-btn>
       </div>
     </b-card>
   </div>
@@ -143,7 +143,8 @@ export default {
       onlyIncidents: false,
       byBusinessKey: false,
       businessKeysText: "",
-      request: null
+      request: null,
+      isRunDisabled: false
     }
   },
   mounted() {
@@ -156,6 +157,9 @@ export default {
       this.processDefinition.id = ""
       this.processDefinition.xml = ""
       this.processDefinition.statistics = []
+    },
+    request(newValue, oldValue) {
+      this.isRunDisabled = false
     }
   },
   methods: {
@@ -234,6 +238,7 @@ export default {
           text: "Modification batch created",
           type: "success"
         });
+        this.isRunDisabled = true
       })
       .catch(error => {
         this.$notify({

--- a/src/views/DefinitionDetailView.vue
+++ b/src/views/DefinitionDetailView.vue
@@ -21,7 +21,9 @@
           ></definition-runtime-instances>
         </b-tab>
         <b-tab title="Runtime incidents">
-          <definition-incidents :definitionId="definitionId"></definition-incidents>
+          <definition-incidents :definitionId="definitionId"
+                                :clickedActivity="clickedActivity">
+          </definition-incidents>
         </b-tab>
         <b-tab title="History instances">
           <definition-history-instances :definitionId="definitionId"></definition-history-instances>


### PR DESCRIPTION
- _Process definition -> runtime instances_: add button "Get all businessKeys" for selected activity in the search form. The button is visible only if option "activityId" is chosen. Click on this button requests all process instances for the selected activity and download a text file with business keys list.
- _Process definition -> runtime incidents_: add a form for filtering incidents by activity id with the button "Get businessKeys" with similar behavior as previous one 
- _Batch modification_: disable the button "Run" after clicking it once, it becomes unlock after editing the request (by user requests: not to accidentally create extra tokens by executing two identical requests with startBefore or startAfter instructions)