### PR TITLE
Bugfix: Remove '/camunda-excamad' from subprocess details URL on a process instance diagram

### DIFF
--- a/src/components/Diagram.vue
+++ b/src/components/Diagram.vue
@@ -385,7 +385,7 @@ export default {
           }
           if (activity.activityType == "callActivity") {
             var baseurl =
-              process.env.NODE_ENV === "production" ? "/camunda-excamad/" : "/";
+              process.env.NODE_ENV === "production" ? "/" : "/";
             var url =
               baseurl + "#/processdetail/" + activity.calledProcessInstanceId;
             var htmllink =


### PR DESCRIPTION
How to reproduce:
- run Excamad with docker
- open Stats and Migration (same with History or any other view of a process instance)
- open an instance of process which has subprocesses
- click its subprocess (UUID) on a diagram

Expected:
- subprocess details should be opened

Actual:
- 404 Not Found page with url `<host>/camunda-excamad/#/processdetails/<subprocess-uuid>`

Workaround:
- If I manually delete /camunda-excamad from the URL and hit Enter, the page displays correctly

I've tested the proposed code fix by `npm run build`, then running the new local docker image and repeating the steps "How to reproduce". The scenario went successfully.

NB:
- I was only able to reproduce the bug when running from docker. When I run Excamad with `npm install` and `npm run serve` or even `NODE_ENV=production npm run serve`, the pages with `/camunda-excamad` before `/#/processdetails/<subprocess-uuid>` display successfully.

Please check if the fix is correct at all and if it can further be simplified to `var base_url = "\";`

![screenshot_2020-12-15_16-25-58](https://user-images.githubusercontent.com/10813578/102243826-a6786e80-3f0c-11eb-9bf4-70cf29932a91.jpg)

![screenshot_2020-12-15_16-28-16](https://user-images.githubusercontent.com/10813578/102243082-d410e800-3f0b-11eb-8569-9e623b7d7b26.jpg)

