### PR TITLE
Cleanup all code related to 'Expert Mode'; and re-enable UI buttons which were dependent on expertMode setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ Excamad is servless app - all api calls made from your browser. You need host pr
 
 # 3. Install
 
-    npm insall
+    npm install
     -
     npm run build  // produce files in dist/
     OR
     npm run serve  // start develop server
 
-You need write global variables in **seetings.js** and **camundasUrl.js**. Don`t foget turn on "Expert mode" in "Systems" to enable danger commands.
+You need write global variables in **settings.js** and **camundasUrl.js**.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5369,7 +5369,8 @@
     "cssom": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
-      "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A=="
+      "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
+      "optional": true
     },
     "cssstyle": {
       "version": "0.2.37",
@@ -7708,7 +7709,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7729,12 +7731,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7749,17 +7753,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7876,7 +7883,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7888,6 +7896,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7902,6 +7911,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7909,12 +7919,14 @@
         "minimist": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7933,6 +7945,7 @@
           "version": "0.5.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -7994,7 +8007,8 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -8022,7 +8036,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8034,6 +8049,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8111,7 +8127,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8147,6 +8164,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8166,6 +8184,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8209,12 +8228,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/public/help/Decisions.md
+++ b/public/help/Decisions.md
@@ -5,7 +5,7 @@
 
   ***
 
-* Update decision (**expert mode**). You need access to current project source in stash to use this function.
+* Update decision. You need access to current project source in stash to use this function.
   ![](help/decision_update.gif)
 
   ---

--- a/public/help/FAQ.md
+++ b/public/help/FAQ.md
@@ -34,12 +34,6 @@ Take REST URL of project (like this _http://bpm-cloud.tinkoff.ru/sme-rko-origina
 
 ---
 
-### Why some buttons is disabled?
-
-You must be _expert_ to enable it.
-
----
-
 ### Why i cannot connect to camunda?
 
 - Wrong url.

--- a/public/help/Incidents.md
+++ b/public/help/Incidents.md
@@ -1,6 +1,6 @@
 ### [Incidents](#/incident) page used to
 
-- Show all incidents and delete(**expert mode**) specific instance, rerun all incidents(**expert mode**) and rerun specific incident.
+- Show all incidents and delete specific instance, rerun all incidents and rerun specific incident.
   ![](help/incidents.gif)
 
   ***

--- a/public/help/ProcessDefinition.md
+++ b/public/help/ProcessDefinition.md
@@ -10,12 +10,12 @@
 
 ---
 
-- Suspend\unsuspend defintion (**expert mode**)
+- Suspend\unsuspend definition
   ![](help/suspend_defintion.gif)
 
 ---
 
-- Suspend\unsuspend job (**expert mode**)
+- Suspend\unsuspend job
   ![](help/suspend_job.gif)
 
 ---

--- a/public/help/ProcessInstance.md
+++ b/public/help/ProcessInstance.md
@@ -1,16 +1,16 @@
 ### Process instance page used to
 
-- Terminate instance (**expert mode**)
+- Terminate instance
   ![](help/terminate.gif)
 
 ---
 
-- Suspend\unsuspend instance (**expert mode**)
+- Suspend\unsuspend instance
   ![](help/suspend_instance.gif)
 
 ---
 
-- Skip current task (**expert mode**)
+- Skip current task
   ![](help/skip_task.gif)
 
 ---
@@ -25,17 +25,17 @@
 
 ---
 
-- Move token (**expert mode**)
+- Move token
   ![](help/move_token.gif)
 
 ---
 
-- Send message (**expert mode**)
+- Send message
   ![](help/send_message.gif)
 
 ---
 
-- Execute jobs (**expert mode**)
+- Execute jobs
   ![](help/execute_jobs.gif)
 
 ---

--- a/public/help/Processes.md
+++ b/public/help/Processes.md
@@ -5,12 +5,12 @@
 
   ***
 
-- Migrate process instances between process definition verions (**expert mode**)
+- Migrate process instances between process definition versions
   ![](help/migrate.gif)
 
   ***
 
-- Bulk replace and add variables in process instances (**expert mode**)
+- Bulk replace and add variables in process instances
   ![](help/variables.gif)
   ***
 

--- a/src/components/ActivityList.vue
+++ b/src/components/ActivityList.vue
@@ -41,7 +41,6 @@
             v-model="historyitem.isSelectedFrom"
             v-if="processInstanceItem.isActive && historyitem.endTime ==null "
             type="checkbox"
-            :disabled="!expertMode"
             @click="onClickSetActivityToMigrate(historyitem)"
           >
         </div>
@@ -80,14 +79,12 @@
           <input
             v-model="historyitem.isSelectedTo"
             type="checkbox"
-            :disabled="!expertMode"
             v-if="processInstanceItem.isActive"
             @click="onClickSetActivityToMigrate(historyitem)"
           >
           <small>
             <b-btn
               size="sm"
-              :disabled="!expertMode"
               @click="moveTokenOnActivity"
               variant="secondary"
               v-if="historyitem.isSelectedTo && selectedActivityTo==historyitem.activityId "
@@ -131,11 +128,6 @@ export default {
       selectedActivityFrom: "",
       selectedActivityTo: ""
     };
-  },
-  computed: {
-    expertMode() {
-      return this.$store.state.expertMode;
-    }
   },
   mounted() {
     setTimeout(() => {

--- a/src/components/DetailDiagram.vue
+++ b/src/components/DetailDiagram.vue
@@ -2,7 +2,7 @@
   <div>
     <h4>Definition {{diagramKey}}</h4>
     <b-btn
-      @click="changeExpertMode"
+      @click="changeEditMode"
       :pressed="editMode"
       size="sm"
       variant="outline-info"
@@ -50,7 +50,7 @@ export default {
     }
   },
   methods: {
-    changeExpertMode() {
+    changeEditMode() {
       this.editMode = !this.editMode;
       this.componentKey = this.componentKey + 1;
     },

--- a/src/components/Diagram.vue
+++ b/src/components/Diagram.vue
@@ -159,7 +159,7 @@ export default {
       });
     },
 
-    changeExpertMode() {
+    changeEditMode() {
       this.wasBuiled = false;
       this.editMode = !this.editMode;
       this.componentKey = this.componentKey + 1;

--- a/src/components/Incident.vue
+++ b/src/components/Incident.vue
@@ -31,7 +31,6 @@
         <b-btn
           class="ml-1"
           variant="danger"
-          :disabled="!expertMode"
           @click="healAndRetry"
         >Rerun all activities</b-btn>
       </b-form>
@@ -86,7 +85,6 @@
                     </td>
                     <td style="word-break:break-all;">
                       <b-btn
-                        :disabled="!expertMode"
                         size="sm"
                         class="ml-2"
                         variant="warning"
@@ -316,9 +314,6 @@ export default {
     this.getAllIncidents();
   },
   computed: {
-    expertMode() {
-      return this.$store.state.expertMode;
-    },
     filterFailedActivity() {
       var array = [];
       this.incidents.forEach(element => {

--- a/src/components/Migration.vue
+++ b/src/components/Migration.vue
@@ -123,9 +123,6 @@ export default {
             return {
                 processDefinitionId: this.processDefinitionFrom
             };
-        },
-        expertMode() {
-            return this.$store.state.expertMode;
         }
     },
     watch: {

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -59,9 +59,6 @@
                             </b-dropdown-item-button>
                             <b-dropdown-divider></b-dropdown-divider>
                             <b-dropdown-item-button @click="clear()">Clear</b-dropdown-item-button>
-                            <b-nav-form>
-                                <b-button v-show="secretButtonPressed" :pressed.sync="expertCurrent" size="sm" @click="commitExpertMode" variant="outline-info">Expert Mode</b-button>
-                            </b-nav-form>
                             <input class="hide" v-on:keyup.right="setVisible" />
                         </b-nav-item-dropdown>
 
@@ -148,12 +145,8 @@ export default {
             substringForTest: TESTSUBSTRING,
             statusDate: '',
             envortment: '',
-            expertCurrent: '',
             secretButtonPressed: false
         }
-    },
-    created() {
-        this.$store.commit('changeExpertMode', localStorage.expertMode1 == 'true')
     },
     mounted() {
         if (localStorage.lastUrl) {
@@ -219,9 +212,6 @@ export default {
         envortmentFromStore() {
             return this.$store.state.envortment
         },
-        expertModeFromStore() {
-            return this.$store.state.expertMode
-        },
         isAuthenticated() {
             return this.$store.getters.isAuthenticated
         },
@@ -230,7 +220,6 @@ export default {
         }
     },
     watch: {
-        expertCurrent(newExpertCurrent) {},
         baseurl() {
             this.getList()
         }
@@ -360,19 +349,6 @@ export default {
                     })
                     .then(() => {})
             }
-        },
-        commitExpertMode() {
-            this.$notify({
-                group: 'foo',
-                title: 'Expert mode on',
-                text: 'Right now ' + this.expertCurrent,
-                type: 'info'
-            })
-            setTimeout(() => {
-                localStorage.expertMode1 = this.expertCurrent
-                this.$store.commit('changeExpertMode', this.expertCurrent)
-            }, 100)
-            //
         },
         setVisible() {
             this.secretButtonPressed = true

--- a/src/components/PrepareCurrentStateAndDiagram.vue
+++ b/src/components/PrepareCurrentStateAndDiagram.vue
@@ -51,18 +51,13 @@ export default {
       currentProcessActivityToShowArray: []
     };
   },
-  computed: {
-    expertMode() {
-      return this.$store.state.expertMode;
-    }
-  },
 
   mounted() {
     this.loadData();
   },
   methods: {
     checkButtons: function(index) {
-      if (index == 0 && this.expertMode == true) {
+      if (index == 0) {
         return true;
       } else return false;
     },

--- a/src/components/VariableModify.vue
+++ b/src/components/VariableModify.vue
@@ -261,11 +261,6 @@ export default {
           });
         });
     }
-  },
-  computed: {
-    expertMode() {
-      return this.$store.state.expertMode;
-    }
   }
 };
 </script>

--- a/src/components/VariableSingleEdit.vue
+++ b/src/components/VariableSingleEdit.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="editVariable">
-    <b-button :disabled="!expertMode" size="lg" variant="link" v-b-modal="'modal'+variableName">
+    <b-button size="lg" variant="link" v-b-modal="'modal'+variableName">
       <font-awesome-icon icon="pen-square"/>
     </b-button>
 
@@ -41,11 +41,6 @@ export default {
   },
   mounted() {
     this.variableNewValue = this.variableOldValue
-  },
-  computed: {
-    expertMode() {
-      return this.$store.state.expertMode;
-    }
   },
   methods: {
     modifyVariable() {

--- a/src/components/batch/BatchTable.vue
+++ b/src/components/batch/BatchTable.vue
@@ -3,7 +3,6 @@
     <b-table :fields="fields" small bordered striped :items="batches" caption-top>
       <template v-slot:cell(delete) >
         <b-button
-          :disabled="!expertMode"
           variant="outline-danger"
           size="sm"
           @click="deleteBatch(row.item.id)"
@@ -13,7 +12,6 @@
       </template>
       <template v-slot:cell(suspend) >
         <b-button
-          :disabled="!expertMode"
           variant="outline-info"
           size="sm"
           @click="suspendBatch(row.item)"
@@ -37,11 +35,6 @@ export default {
         { key: "delete", label: "Delete" },
 
       ]
-    }
-  },
-  computed: {
-    expertMode() {
-      return this.$store.state.expertMode;
     }
   },
   mounted() {

--- a/src/components/decisions/DecisionDiagram.vue
+++ b/src/components/decisions/DecisionDiagram.vue
@@ -26,7 +26,7 @@
       <hr>
       <deploy
         class="mb-2"
-        v-if="(newSavedXML && wasCommited) || expertMode "
+        v-if="(newSavedXML && wasCommited) || editMode "
         extension="dmn"
         :diagramInXML="newSavedXML"
       ></deploy>
@@ -69,10 +69,6 @@ export default {
       var lastIndex = prjName.lastIndexOf("/");
       prjName = prjName.substring(lastIndex + 1, prjName.length);
       return prjName;
-    },
-    expertMode() {
-      //
-      return this.$store.state.expertMode;
     },
     pathToFile() {
       return this.projectName + "/src/main/resources" + this.decisionMeta.resource.replace("BOOT-INF/classes", "");

--- a/src/components/detail-instance/MoveToken.vue
+++ b/src/components/detail-instance/MoveToken.vue
@@ -14,7 +14,7 @@
           class="mb-2 mr-sm-2 mb-sm-0"
         />
 
-        <b-button @click="moveToken" :disabled="!expertMode" variant="outline-danger">Move</b-button>
+        <b-button @click="moveToken" variant="outline-danger">Move</b-button>
         <br />
       </b-form>
       <small>{{calculateHelp()}}</small>
@@ -52,9 +52,6 @@ export default {
   computed: {
     profile() {
       return this.$store.getters.getProfile;
-    },
-    expertMode() {
-      return this.$store.state.expertMode;
     }
   },
   mounted() {

--- a/src/components/detail-instance/SendMessage.vue
+++ b/src/components/detail-instance/SendMessage.vue
@@ -8,7 +8,7 @@
           :options="messageList"
           class="mb-2 mr-sm-2 mb-sm-0"
         />
-        <b-button @click="sendMessage" :disabled="!expertMode" variant="outline-danger">Send</b-button>
+        <b-button @click="sendMessage" variant="outline-danger">Send</b-button>
         <br>
       </b-form>
     </b-card>
@@ -35,9 +35,6 @@ export default {
     },
     isAuthenticated() {
       return this.$store.getters.isAuthenticated;
-    },
-    expertMode() {
-      return this.$store.state.expertMode;
     }
   },
   mounted() {

--- a/src/components/detail-process-definition/DefinitionDiagram.vue
+++ b/src/components/detail-process-definition/DefinitionDiagram.vue
@@ -19,7 +19,6 @@
       <b-btn
         size="sm"
         v-if="clickedElement !=null"
-        :disabled="!expertMode()"
         :variant="getVariant()"
         @click="suspendCurrentJobDefinition()"
       >
@@ -28,7 +27,6 @@
       </b-btn>
       <b-form-checkbox
         v-b-tooltip.hover
-        :disabled="!expertMode()"
         class="ml-3"
         title="When the value is set to true, all jobs of the job definitions with the given process definition id will be activated or suspended and when the value is set to false, the suspension state of all jobs of the job definitions with the given process definition id will not be updated."
         size="sm"
@@ -64,9 +62,6 @@ export default {
     this.getJobs();
   },
   methods: {
-    expertMode() {
-      return this.$store.state.expertMode;
-    },
     PassDiagramClick(payload) {
       this.clickedElement = payload;
       this.clickedJobDefinition = {};

--- a/src/components/detail-process-definition/DefinitionMetadata.vue
+++ b/src/components/detail-process-definition/DefinitionMetadata.vue
@@ -17,7 +17,6 @@
           <start-definition class="mb-2 text-left" :definitionId="definitionId"></start-definition>
           <b-btn
             v-b-tooltip.hover
-            :disabled="!expertMode()"
             title="This process definition will be suspended, so that it will not be possible to start new process instances based on this process definition."
             @click="suspendCurrentId()"
             size="sm"
@@ -30,7 +29,6 @@
 
           <b-form-checkbox
             v-b-tooltip.hover
-            :disabled="!expertMode()"
             class="pull-right"
             title="All existing instance will suspend"
             size="sm"
@@ -120,9 +118,6 @@ export default {
             element.historyCount = response.data.count;
           });
       });
-    },
-    expertMode() {
-      return this.$store.state.expertMode;
     },
 
     getVersionsByKey() {

--- a/src/components/detail-process-definition/StartDefinition.vue
+++ b/src/components/detail-process-definition/StartDefinition.vue
@@ -149,9 +149,6 @@ export default {
     }
   },
   methods: {
-    expertMode() {
-      return this.$store.state.expertMode;
-    },
     getStartFormVariables() {
       this.$api().get("/process-definition/" + this.definitionId + "/form-variables").then(response => {
         if (response.data != null) {

--- a/src/components/detail-process-diagram/DetailDiagram.vue
+++ b/src/components/detail-process-diagram/DetailDiagram.vue
@@ -2,7 +2,7 @@
   <div>
     <h4>Definition {{diagramKey}}</h4>
     <b-btn
-      @click="changeExpertMode"
+      @click="changeEditMode"
       :pressed="editMode"
       size="sm"
       variant="outline-info"
@@ -61,7 +61,7 @@ export default {
         return this.processDefinitionId;
       } else return null;
     },
-    changeExpertMode() {
+    changeEditMode() {
       this.editMode = !this.editMode;
       this.componentKey = this.componentKey + 1;
     },

--- a/src/components/detail-process-diagram/DetailProcessStat.vue
+++ b/src/components/detail-process-diagram/DetailProcessStat.vue
@@ -13,7 +13,6 @@
         <b-col v-if="processInstanceRuntimeData" col lg="2" class="text-right">
           <b-btn
             v-b-tooltip.hover
-            :disabled="!expertMode()"
             title="Suspending a process instance means that the execution is stopped, so the token state will not change. However, actions that do not change token state, like setting or removing variables, etc. will still succeed.
 
 Tasks belonging to this process instance will also be suspended. This means that any actions influencing the tasks' lifecycles will fail"
@@ -108,9 +107,6 @@ export default {
           });
           this.getProcessDetail();
         });
-    },
-    expertMode() {
-      return this.$store.state.expertMode;
     },
     getProcessDetail() {
       this.$api()

--- a/src/components/detail-process-instance/DetailDiagram.vue
+++ b/src/components/detail-process-instance/DetailDiagram.vue
@@ -2,7 +2,7 @@
   <div>
     <h4>Definition {{diagramKey}}</h4>
     <b-btn
-      @click="changeExpertMode"
+      @click="changeEditMode"
       :pressed="editMode"
       size="sm"
       variant="outline-info"
@@ -61,7 +61,7 @@ export default {
         return this.processDefinitionId;
       } else return null;
     },
-    changeExpertMode() {
+    changeEditMode() {
       this.editMode = !this.editMode;
       this.componentKey = this.componentKey + 1;
     },

--- a/src/components/detail-process-instance/DetailJobs.vue
+++ b/src/components/detail-process-instance/DetailJobs.vue
@@ -119,9 +119,6 @@ export default {
     }, 200);
   },
   computed: {
-    expertMode() {
-      return this.$store.state.expertMode;
-    },
     baseurl() {
       return this.$store.state.baseurl;
     }

--- a/src/components/detail-process-instance/DetailProcessStat.vue
+++ b/src/components/detail-process-instance/DetailProcessStat.vue
@@ -8,7 +8,6 @@
               v-b-tooltip.hover
               title="Terminate instance"
               @click="deleteInstance"
-              :disabled="!expertMode()"
               variant="danger"
               size="sm"
             >X</b-btn>
@@ -22,7 +21,6 @@
           <b-btn
             class="mt-3"
             v-b-tooltip.hover
-            :disabled="!expertMode()"
             title="Suspending a process instance means that the execution is stopped, so the token state will not change. However, actions that do not change token state, like setting or removing variables, etc. will still succeed.
 
 Tasks belonging to this process instance will also be suspended. This means that any actions influencing the tasks' lifecycles will fail"
@@ -164,9 +162,6 @@ export default {
           });
           this.getProcessDetail();
         });
-    },
-    expertMode() {
-      return this.$store.state.expertMode;
     },
     getProcessDetail() {
       this.$api()

--- a/src/components/detail-process-instance/MoveToken.vue
+++ b/src/components/detail-process-instance/MoveToken.vue
@@ -15,7 +15,7 @@
           <option v-bind:key="item" v-for="item in possibleActivitySimpleArray">{{ item }}</option>
         </datalist>
 
-        <b-button @click="moveToken" :disabled="!expertMode" variant="outline-danger">Move</b-button>
+        <b-button @click="moveToken" variant="outline-danger">Move</b-button>
         <br />
       </b-form>
       <small>{{calculateHelp()}}</small>
@@ -53,9 +53,6 @@ export default {
     },
     isAuthenticated() {
       return this.$store.getters.isAuthenticated;
-    },
-    expertMode() {
-      return this.$store.state.expertMode;
     }
   },
   mounted() {

--- a/src/components/detail-process-instance/PrepareCurrentStateAndDiagram.vue
+++ b/src/components/detail-process-instance/PrepareCurrentStateAndDiagram.vue
@@ -77,18 +77,13 @@ export default {
       currentProcessActivityToShowArray: []
     };
   },
-  computed: {
-    expertMode() {
-      return this.$store.state.expertMode;
-    }
-  },
 
   mounted() {
     this.loadData();
   },
   methods: {
     checkButtons: function (index) {
-      if (index == 0 && this.expertMode == true) {
+      if (index == 0) {
         return true;
       } else return false;
     },

--- a/src/components/detail-process-instance/SendMessage.vue
+++ b/src/components/detail-process-instance/SendMessage.vue
@@ -8,7 +8,7 @@
           :options="messageList"
           class="mb-2 mr-sm-2 mb-sm-0"
         />
-        <b-button @click="sendMessage" :disabled="!expertMode" variant="outline-danger">Send</b-button>
+        <b-button @click="sendMessage" variant="outline-danger">Send</b-button>
         <br>
       </b-form>
     </b-card>
@@ -35,9 +35,6 @@ export default {
     },
     isAuthenticated() {
       return this.$store.getters.isAuthenticated;
-    },
-    expertMode() {
-      return this.$store.state.expertMode;
     }
   },
   mounted() {

--- a/src/components/tasklist/TaskList.vue
+++ b/src/components/tasklist/TaskList.vue
@@ -24,7 +24,6 @@
         </small>
       </b-card>
       <b-btn
-        :disabled="!expertMode"
         class="mb-2"
         size="sm"
         variant="outline-warning"
@@ -102,9 +101,6 @@ export default {
   computed: {
     taskId() {
       return this.$store.state.taskId;
-    },
-    expertMode() {
-      return this.$store.state.expertMode;
     },
     profile() {
       return this.$store.getters.getProfile;

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -28,7 +28,6 @@ export default new Vuex.Store({
     restPassword: null,
     restBearerToken: null,
     restAuthType: null,
-    expertMode: false,
     restAuthArray:  [],
     taskId: '',
     secureDate: null,
@@ -90,9 +89,6 @@ export default new Vuex.Store({
     },
     changeServerStatus(state, status) {
       state.serverStatus = status;
-    },
-    changeExpertMode(state, expertMode) {
-      state.expertMode = expertMode;
     },
     changeTaskId(state, taskId) {
       state.taskId = taskId;


### PR DESCRIPTION
At first, my intention was to enable a couple of buttons which were dependent on enabling Expert Mode.
But then I decided to try to wipe out all code related to 'expertMode' as it is not relevant any more and should be considered obsolete.

Please look into the changes very carefully.

Disclaimer: 
I am absolutely not an expert in frontend and Vue.js.